### PR TITLE
Add Flask API tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ sendgrid==6.11.0
 Flask-Cors==4.0.0
 requests==2.31.0
 beautifulsoup4==4.12.3
+pytest==8.1.1

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,23 @@
+import pytest
+from unittest.mock import patch, MagicMock
+
+import app
+
+@pytest.fixture
+def client():
+    app.app.config["TESTING"] = True
+    with app.app.test_client() as client:
+        yield client
+
+def test_add_success(client):
+    with patch.object(app, "games_collection") as mock_col:
+        mock_col.insert_one.return_value = MagicMock(inserted_id="1")
+        response = client.post("/add", json={"name": "Game", "platform": "PC"})
+        assert response.status_code == 201
+        assert response.get_json()["message"] == "Game added successfully!"
+        mock_col.insert_one.assert_called_once_with({"name": "Game", "platform": "PC", "image_url": None})
+
+def test_add_missing_fields(client):
+    response = client.post("/add", json={"name": "Game"})
+    assert response.status_code == 400
+    assert response.get_json()["message"] == "Name and platform are required."


### PR DESCRIPTION
## Summary
- create pytest tests for adding games via the `/add` endpoint
- verify failure for missing required data
- include pytest in requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_6853e1fedf28832186107c537512b5ab